### PR TITLE
feat(backend): harden API validation and add tx observability

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,32 @@
+name: Backend CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy -p backend --all-targets -- -D warnings
+
+      - name: Run tests
+        run: cargo test -p backend
+
+      - name: Build release
+        run: cargo build -p backend --release

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -1,0 +1,6 @@
+RPC_URL=https://api.mainnet-beta.solana.com
+PROGRAM_ID=replace_with_deployed_program_id
+DATABASE_URL=postgres://ephemeral_vault:replace_with_password@postgres:5432/ephemeral_vault
+SERVER_HOST=0.0.0.0
+SERVER_PORT=8080
+RUST_LOG=info,tower_http=info

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -10,7 +10,7 @@ tokio = { version = "1", features = ["full"] }
 
 # Web framework
 axum = { version = "0.7", features = ["ws", "macros"] }
-tower = "0.4"
+tower = { version = "0.4", features = ["util"] }
 tower-http = { version = "0.5", features = ["cors", "trace"] }
 
 # Serialization

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,27 @@
+FROM rust:1.85-slim AS builder
+
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock Anchor.toml ./
+COPY backend ./backend
+COPY programs ./programs
+
+RUN cargo build --release -p backend
+
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /app/target/release/backend /usr/local/bin/ephemeral-vault-backend
+COPY backend/migrations ./migrations
+
+ENV SERVER_HOST=0.0.0.0
+ENV SERVER_PORT=8080
+
+EXPOSE 8080
+
+CMD ["ephemeral-vault-backend"]

--- a/backend/docker-compose.prod.yml
+++ b/backend/docker-compose.prod.yml
@@ -1,0 +1,35 @@
+services:
+  api:
+    build:
+      context: ..
+      dockerfile: backend/Dockerfile
+    env_file:
+      - .env.production
+    environment:
+      DATABASE_URL: postgres://ephemeral_vault:${POSTGRES_PASSWORD:-ephemeral_vault}@postgres:5432/ephemeral_vault
+      SERVER_HOST: 0.0.0.0
+      SERVER_PORT: 8080
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: ephemeral_vault
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-ephemeral_vault}
+      POSTGRES_DB: ephemeral_vault
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ephemeral_vault -d ephemeral_vault"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  postgres_data:

--- a/backend/migrations/20260717000000_prod_constraints.sql
+++ b/backend/migrations/20260717000000_prod_constraints.sql
@@ -1,0 +1,40 @@
+-- Production safety constraints for trade ingestion.
+
+CREATE UNIQUE INDEX IF NOT EXISTS trades_tx_hash_unique
+  ON trades (tx_hash);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'trades_amount_sol_nonnegative'
+  ) THEN
+    ALTER TABLE trades
+      ADD CONSTRAINT trades_amount_sol_nonnegative CHECK (amount_sol >= 0);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'trades_fee_sol_nonnegative'
+  ) THEN
+    ALTER TABLE trades
+      ADD CONSTRAINT trades_fee_sol_nonnegative CHECK (fee_sol >= 0);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'trades_slot_nonnegative'
+  ) THEN
+    ALTER TABLE trades
+      ADD CONSTRAINT trades_slot_nonnegative CHECK (slot IS NULL OR slot >= 0);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'trades_required_text'
+  ) THEN
+    ALTER TABLE trades
+      ADD CONSTRAINT trades_required_text CHECK (
+        length(btrim(vault_address)) > 0
+        AND length(btrim(tx_hash)) > 0
+        AND length(btrim(trade_type)) > 0
+        AND length(btrim(status)) > 0
+      );
+  END IF;
+END $$;

--- a/backend/src/db/models.rs
+++ b/backend/src/db/models.rs
@@ -2,6 +2,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::error::{AppError, Result};
+
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct TradeRecord {
     pub id: Uuid,
@@ -36,4 +38,77 @@ pub struct NewTrade {
     pub fee_sol: f64,
     pub status: String,
     pub slot: Option<i64>,
+}
+
+impl NewTrade {
+    pub fn validate(&self) -> Result<()> {
+        validate_required_text(&self.vault_address, "vault_address")?;
+        validate_required_text(&self.tx_hash, "tx_hash")?;
+        validate_required_text(&self.trade_type, "trade_type")?;
+        validate_required_text(&self.status, "status")?;
+
+        if !self.amount_sol.is_finite() || self.amount_sol < 0.0 {
+            return Err(AppError::Validation(
+                "amount_sol must be a finite non-negative number".into(),
+            ));
+        }
+
+        if !self.fee_sol.is_finite() || self.fee_sol < 0.0 {
+            return Err(AppError::Validation(
+                "fee_sol must be a finite non-negative number".into(),
+            ));
+        }
+
+        if matches!(self.slot, Some(slot) if slot < 0) {
+            return Err(AppError::Validation("slot must be non-negative".into()));
+        }
+
+        Ok(())
+    }
+}
+
+fn validate_required_text(value: &str, field: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        return Err(AppError::Validation(format!("{field} must not be empty")));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_trade() -> NewTrade {
+        NewTrade {
+            vault_address: "vault".into(),
+            tx_hash: "tx".into(),
+            trade_type: "buy".into(),
+            amount_sol: 1.0,
+            fee_sol: 0.000005,
+            status: "confirmed".into(),
+            slot: Some(42),
+        }
+    }
+
+    #[test]
+    fn validates_trade_payload() {
+        assert!(valid_trade().validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_trade_text_fields() {
+        let mut trade = valid_trade();
+        trade.tx_hash = " ".into();
+
+        assert!(trade.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_negative_amounts() {
+        let mut trade = valid_trade();
+        trade.amount_sol = -1.0;
+
+        assert!(trade.validate().is_err());
+    }
 }

--- a/backend/src/db/queries.rs
+++ b/backend/src/db/queries.rs
@@ -1,5 +1,5 @@
 use crate::db::models::{NewTrade, TradeRecord};
-use crate::error::Result;
+use crate::error::{AppError, Result};
 use sqlx::PgPool;
 
 pub async fn insert_trade(pool: &PgPool, trade: &NewTrade) -> Result<TradeRecord> {
@@ -19,8 +19,19 @@ pub async fn insert_trade(pool: &PgPool, trade: &NewTrade) -> Result<TradeRecord
     .bind(&trade.status)
     .bind(trade.slot)
     .fetch_one(pool)
-    .await?;
+    .await
+    .map_err(map_insert_trade_error)?;
     Ok(rec)
+}
+
+fn map_insert_trade_error(err: sqlx::Error) -> AppError {
+    if let sqlx::Error::Database(db_err) = &err {
+        if db_err.constraint() == Some("trades_tx_hash_unique") {
+            return AppError::Conflict("tx_hash already exists".into());
+        }
+    }
+
+    AppError::Database(err)
 }
 
 pub async fn get_trades_for_vault(

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -8,6 +8,9 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum AppError {
+    #[error("Validation error: {0}")]
+    Validation(String),
+
     #[error("Vault not found: {0}")]
     VaultNotFound(String),
 
@@ -26,6 +29,9 @@ pub enum AppError {
     #[error("Solana RPC error: {0}")]
     SolanaRpc(String),
 
+    #[error("Conflict: {0}")]
+    Conflict(String),
+
     #[error("Database error: {0}")]
     Database(#[from] sqlx::Error),
 
@@ -42,19 +48,21 @@ pub enum AppError {
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let (status, message) = match &self {
+            AppError::Validation(_) => (StatusCode::BAD_REQUEST, self.to_string()),
             AppError::VaultNotFound(_) => (StatusCode::NOT_FOUND, self.to_string()),
             AppError::SessionExpired => (StatusCode::GONE, self.to_string()),
             AppError::ExceedsApprovedLimit => (StatusCode::BAD_REQUEST, self.to_string()),
             AppError::UnauthorizedDelegate => (StatusCode::FORBIDDEN, self.to_string()),
-            AppError::InvalidSignature(_) => (StatusCode::UNAUTHORIZED, self.to_string()),
+            AppError::InvalidSignature(_) => (StatusCode::BAD_REQUEST, self.to_string()),
             AppError::SolanaRpc(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
+            AppError::Conflict(_) => (StatusCode::CONFLICT, self.to_string()),
             _ => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Internal server error".into(),
             ),
         };
 
-        (status, Json(json!({ "error": message }))).into_response()
+        (status, Json(json!({ "error": { "message": message } }))).into_response()
     }
 }
 

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::{pubkey::Pubkey, signature::Signature};
 
 use crate::{
     db::{models::NewTrade, queries},
@@ -14,6 +14,12 @@ use crate::{
     solana,
     state::AppState,
 };
+
+const MIN_APPROVED_AMOUNT_LAMPORTS: u64 = 1_000_000;
+const MAX_APPROVED_AMOUNT_LAMPORTS: u64 = 1_000_000_000_000;
+const MIN_DEPOSIT_LAMPORTS: u64 = 1_000_000;
+const MAX_DEPOSIT_LAMPORTS: u64 = 100_000_000_000;
+const MAX_SESSION_DURATION_SECONDS: i64 = 3_600;
 
 #[derive(Debug, Deserialize)]
 pub struct PaginationQuery {
@@ -81,9 +87,47 @@ pub struct CleanupRequest {
     cleaner_pubkey: String,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SimulateTransactionRequest {
+    transaction_base64: String,
+}
+
 fn parse_pubkey(raw: &str, field: &str) -> Result<Pubkey> {
     raw.parse::<Pubkey>()
         .map_err(|e| AppError::InvalidSignature(format!("invalid {field}: {e}")))
+}
+
+fn validate_lamports_range(value: u64, field: &str, min: u64, max: u64) -> Result<()> {
+    if value < min || value > max {
+        return Err(AppError::Validation(format!(
+            "{field} must be between {min} and {max} lamports"
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_positive_lamports(value: u64, field: &str) -> Result<()> {
+    if value == 0 {
+        return Err(AppError::Validation(format!(
+            "{field} must be greater than 0"
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_custom_duration(duration: Option<i64>) -> Result<()> {
+    if let Some(duration) = duration {
+        if duration <= 0 || duration > MAX_SESSION_DURATION_SECONDS {
+            return Err(AppError::Validation(format!(
+                "customDurationSeconds must be between 1 and {MAX_SESSION_DURATION_SECONDS}"
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 pub async fn health() -> Json<Value> {
@@ -187,6 +231,7 @@ pub async fn create_trade(
     State(state): State<AppState>,
     Json(body): Json<NewTrade>,
 ) -> Result<Json<crate::db::models::TradeRecord>> {
+    body.validate()?;
     let trade = queries::insert_trade(&state.db, &body).await?;
     Ok(Json(trade))
 }
@@ -201,6 +246,21 @@ pub async fn tx_create_vault(
         .as_deref()
         .map(|raw| parse_pubkey(raw, "delegatePubkey"))
         .transpose()?;
+    validate_lamports_range(
+        body.approved_amount_lamports,
+        "approvedAmountLamports",
+        MIN_APPROVED_AMOUNT_LAMPORTS,
+        MAX_APPROVED_AMOUNT_LAMPORTS,
+    )?;
+    validate_custom_duration(body.custom_duration_seconds)?;
+    if let Some(amount) = body.initial_deposit_lamports.filter(|amount| *amount > 0) {
+        validate_lamports_range(
+            amount,
+            "initialDepositLamports",
+            MIN_DEPOSIT_LAMPORTS,
+            MAX_DEPOSIT_LAMPORTS,
+        )?;
+    }
 
     let tx = solana::build_create_vault_tx(
         &state.rpc,
@@ -221,6 +281,12 @@ pub async fn tx_deposit(
     Json(body): Json<AmountRequest>,
 ) -> Result<Json<solana::TxEnvelope>> {
     let user = parse_pubkey(&body.user_pubkey, "userPubkey")?;
+    validate_lamports_range(
+        body.amount_lamports,
+        "amountLamports",
+        MIN_DEPOSIT_LAMPORTS,
+        MAX_DEPOSIT_LAMPORTS,
+    )?;
     let tx =
         solana::build_deposit_tx(&state.rpc, &state.config, user, body.amount_lamports).await?;
     Ok(Json(tx))
@@ -231,6 +297,9 @@ pub async fn tx_withdraw(
     Json(body): Json<AmountRequest>,
 ) -> Result<Json<solana::TxEnvelope>> {
     let user = parse_pubkey(&body.user_pubkey, "userPubkey")?;
+    if body.amount_lamports > 0 {
+        validate_positive_lamports(body.amount_lamports, "amountLamports")?;
+    }
     let tx =
         solana::build_withdraw_tx(&state.rpc, &state.config, user, body.amount_lamports).await?;
     Ok(Json(tx))
@@ -278,6 +347,7 @@ pub async fn tx_approve_delegate(
 ) -> Result<Json<solana::TxEnvelope>> {
     let user = parse_pubkey(&body.user_pubkey, "userPubkey")?;
     let delegate = parse_pubkey(&body.delegate_pubkey, "delegatePubkey")?;
+    validate_custom_duration(body.custom_duration_seconds)?;
     let tx = solana::build_approve_delegate_tx(
         &state.rpc,
         &state.config,
@@ -303,6 +373,12 @@ pub async fn tx_update_approved_amount(
     Json(body): Json<UpdateApprovedAmountRequest>,
 ) -> Result<Json<solana::TxEnvelope>> {
     let user = parse_pubkey(&body.user_pubkey, "userPubkey")?;
+    validate_lamports_range(
+        body.new_approved_amount_lamports,
+        "newApprovedAmountLamports",
+        MIN_APPROVED_AMOUNT_LAMPORTS,
+        MAX_APPROVED_AMOUNT_LAMPORTS,
+    )?;
     let tx = solana::build_update_approved_amount_tx(
         &state.rpc,
         &state.config,
@@ -319,6 +395,13 @@ pub async fn tx_execute_trade(
 ) -> Result<Json<solana::TxEnvelope>> {
     let vault = parse_pubkey(&body.vault_pubkey, "vaultPubkey")?;
     let delegate = parse_pubkey(&body.delegate_pubkey, "delegatePubkey")?;
+    validate_positive_lamports(body.trade_fee_lamports, "tradeFeeLamports")?;
+    validate_lamports_range(
+        body.trade_amount_lamports,
+        "tradeAmountLamports",
+        MIN_APPROVED_AMOUNT_LAMPORTS,
+        MAX_APPROVED_AMOUNT_LAMPORTS,
+    )?;
     let tx = solana::build_execute_trade_tx(
         &state.rpc,
         &state.config,
@@ -339,4 +422,57 @@ pub async fn tx_cleanup(
     let cleaner = parse_pubkey(&body.cleaner_pubkey, "cleanerPubkey")?;
     let tx = solana::build_cleanup_tx(&state.rpc, &state.config, vault, cleaner).await?;
     Ok(Json(tx))
+}
+
+pub async fn tx_simulate(
+    State(state): State<AppState>,
+    Json(body): Json<SimulateTransactionRequest>,
+) -> Result<Json<solana::TxSimulationDto>> {
+    if body.transaction_base64.trim().is_empty() {
+        return Err(AppError::Validation(
+            "transactionBase64 must not be empty".into(),
+        ));
+    }
+
+    let simulation =
+        solana::simulate_transaction_base64(&state.rpc, &body.transaction_base64).await?;
+    Ok(Json(simulation))
+}
+
+pub async fn tx_status(
+    State(state): State<AppState>,
+    Path(signature): Path<String>,
+) -> Result<Json<solana::TxStatusDto>> {
+    let signature = signature
+        .parse::<Signature>()
+        .map_err(|e| AppError::Validation(format!("invalid signature: {e}")))?;
+    let status = solana::fetch_transaction_status(&state.rpc, signature).await?;
+    Ok(Json(status))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_lamport_ranges() {
+        assert!(validate_lamports_range(1_000_000, "amount", 1_000_000, 2_000_000).is_ok());
+        assert!(validate_lamports_range(999_999, "amount", 1_000_000, 2_000_000).is_err());
+        assert!(validate_lamports_range(2_000_001, "amount", 1_000_000, 2_000_000).is_err());
+    }
+
+    #[test]
+    fn validates_positive_lamports() {
+        assert!(validate_positive_lamports(1, "amount").is_ok());
+        assert!(validate_positive_lamports(0, "amount").is_err());
+    }
+
+    #[test]
+    fn validates_custom_duration_bounds() {
+        assert!(validate_custom_duration(None).is_ok());
+        assert!(validate_custom_duration(Some(1)).is_ok());
+        assert!(validate_custom_duration(Some(MAX_SESSION_DURATION_SECONDS)).is_ok());
+        assert!(validate_custom_duration(Some(0)).is_err());
+        assert!(validate_custom_duration(Some(MAX_SESSION_DURATION_SECONDS + 1)).is_err());
+    }
 }

--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -9,6 +9,13 @@ pub fn router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(handlers::health))
         .route("/ready", get(handlers::ready))
+        .merge(api_routes())
+        .nest("/api/v1", api_routes())
+        .with_state(state)
+}
+
+fn api_routes() -> Router<AppState> {
+    Router::new()
         .route("/vault/:user_pubkey", get(handlers::get_vault))
         .route("/vault_stats/:user_pubkey", get(handlers::get_vault_stats))
         .route("/trades/:vault_pubkey", get(handlers::get_trades))
@@ -28,5 +35,74 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/tx/execute_trade", post(handlers::tx_execute_trade))
         .route("/tx/cleanup", post(handlers::tx_cleanup))
-        .with_state(state)
+        .route("/tx/simulate", post(handlers::tx_simulate))
+        .route("/tx/status/:signature", get(handlers::tx_status))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use axum::{
+        body::{to_bytes, Body},
+        http::{Request, StatusCode},
+    };
+    use solana_client::nonblocking::rpc_client::RpcClient;
+    use solana_sdk::commitment_config::CommitmentConfig;
+    use sqlx::postgres::PgPoolOptions;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    fn test_state() -> AppState {
+        AppState {
+            config: Config {
+                rpc_url: "http://127.0.0.1:8899".into(),
+                database_url: "postgres://postgres:postgres@localhost:5432/ephemeral_vault".into(),
+                program_id: "3L2LMJHHvgaGnvQ2ic7a5yu6DffLfoAQFLwFSjFJ4QQt".into(),
+                server_host: "127.0.0.1".into(),
+                server_port: 8080,
+            },
+            db: PgPoolOptions::new()
+                .connect_lazy("postgres://postgres:postgres@localhost:5432/ephemeral_vault")
+                .expect("lazy postgres pool"),
+            rpc: Arc::new(RpcClient::new_with_commitment(
+                "http://127.0.0.1:8899".into(),
+                CommitmentConfig::confirmed(),
+            )),
+        }
+    }
+
+    #[tokio::test]
+    async fn health_route_returns_ok() {
+        let response = router(test_state())
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        assert_eq!(&body[..], br#"{"status":"ok"}"#);
+    }
+
+    #[tokio::test]
+    async fn versioned_trade_route_is_registered() {
+        let response = router(test_state())
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/trades/TEST")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_ne!(response.status(), StatusCode::NOT_FOUND);
+    }
 }

--- a/backend/src/solana/mod.rs
+++ b/backend/src/solana/mod.rs
@@ -7,6 +7,7 @@ use solana_sdk::{
     instruction::{AccountMeta, Instruction},
     message::Message,
     pubkey::Pubkey,
+    signature::Signature,
     system_program,
     transaction::Transaction,
 };
@@ -106,6 +107,26 @@ pub struct VaultStatsDto {
 pub struct TxEnvelope {
     pub transaction_base64: String,
     pub vault_pda: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TxSimulationDto {
+    pub ok: bool,
+    pub error: Option<String>,
+    pub logs: Vec<String>,
+    pub units_consumed: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TxStatusDto {
+    pub signature: String,
+    pub found: bool,
+    pub slot: Option<u64>,
+    pub confirmations: Option<usize>,
+    pub confirmation_status: Option<String>,
+    pub error: Option<String>,
 }
 
 fn to_sol(lamports: u64) -> f64 {
@@ -234,6 +255,64 @@ fn encode_transaction(
     Ok(TxEnvelope {
         transaction_base64: BASE64.encode(bytes),
         vault_pda: vault_pda.to_string(),
+    })
+}
+
+pub async fn simulate_transaction_base64(
+    rpc: &RpcClient,
+    transaction_base64: &str,
+) -> Result<TxSimulationDto> {
+    let bytes = BASE64
+        .decode(transaction_base64)
+        .map_err(|e| AppError::Validation(format!("transactionBase64 is invalid base64: {e}")))?;
+    let tx = bincode::deserialize::<Transaction>(&bytes).map_err(|e| {
+        AppError::Validation(format!("transactionBase64 is not a transaction: {e}"))
+    })?;
+
+    let response = rpc
+        .simulate_transaction(&tx)
+        .await
+        .map_err(|e| AppError::SolanaRpc(format!("failed to simulate transaction: {e}")))?;
+
+    let error = response.value.err.map(|err| format!("{err:?}"));
+    Ok(TxSimulationDto {
+        ok: error.is_none(),
+        error,
+        logs: response.value.logs.unwrap_or_default(),
+        units_consumed: response.value.units_consumed,
+    })
+}
+
+pub async fn fetch_transaction_status(
+    rpc: &RpcClient,
+    signature: Signature,
+) -> Result<TxStatusDto> {
+    let response = rpc
+        .get_signature_statuses(&[signature])
+        .await
+        .map_err(|e| AppError::SolanaRpc(format!("failed to fetch transaction status: {e}")))?;
+    let status = response.value.into_iter().next().flatten();
+
+    let Some(status) = status else {
+        return Ok(TxStatusDto {
+            signature: signature.to_string(),
+            found: false,
+            slot: None,
+            confirmations: None,
+            confirmation_status: None,
+            error: None,
+        });
+    };
+
+    Ok(TxStatusDto {
+        signature: signature.to_string(),
+        found: true,
+        slot: Some(status.slot),
+        confirmations: status.confirmations,
+        confirmation_status: status
+            .confirmation_status
+            .map(|status| format!("{status:?}").to_lowercase()),
+        error: status.err.map(|err| format!("{err:?}")),
     })
 }
 

--- a/programs/ephemeralvault/src/lib.rs
+++ b/programs/ephemeralvault/src/lib.rs
@@ -47,7 +47,7 @@ pub mod ephemeral_vault {
         approved_amount: u64,
     ) -> Result<()> {
         require!(
-            approved_amount >= MIN_APPROVED_AMOUNT && approved_amount <= MAX_APPROVED_AMOUNT,
+            (MIN_APPROVED_AMOUNT..=MAX_APPROVED_AMOUNT).contains(&approved_amount),
             EphemeralVaultError::InvalidApprovedAmount
         );
 
@@ -403,7 +403,7 @@ pub mod ephemeral_vault {
         // Return all available balance
         let vault_lamports = vault.to_account_info().lamports();
         let rent_exempt = Rent::get()?.minimum_balance(vault.to_account_info().data_len());
-        let transferable = vault_lamports.checked_sub(rent_exempt).unwrap_or(0);
+        let transferable = vault_lamports.saturating_sub(rent_exempt);
 
         let returned_amount = if transferable > 0 {
             move_lamports(
@@ -478,8 +478,7 @@ pub mod ephemeral_vault {
             EphemeralVaultError::Unauthorized
         );
         require!(
-            new_approved_amount >= MIN_APPROVED_AMOUNT
-                && new_approved_amount <= MAX_APPROVED_AMOUNT,
+            (MIN_APPROVED_AMOUNT..=MAX_APPROVED_AMOUNT).contains(&new_approved_amount),
             EphemeralVaultError::InvalidApprovedAmount
         );
         require!(
@@ -576,7 +575,7 @@ pub mod ephemeral_vault {
         // Calculate rewards
         let vault_lamports = vault.to_account_info().lamports();
         let rent_exempt = Rent::get()?.minimum_balance(vault.to_account_info().data_len());
-        let available = vault_lamports.checked_sub(rent_exempt).unwrap_or(0);
+        let available = vault_lamports.saturating_sub(rent_exempt);
 
         let (to_user, reward) = if available > 0 {
             let reward = available


### PR DESCRIPTION
- add structured validation and consistent error responses
- add production DB constraints and duplicate tx_hash handling
- add transaction simulation and status endpoints
- add /api/v1 route aliases while preserving existing routes
- add backend Docker, production env, compose, and CI setup
- expand backend tests and fix clippy warnings